### PR TITLE
fix: add extend flag to opionally generate config within extend key o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-//README
 # Style Dictionary Tailwind CSS Transformer
 
 [![Release](https://badgen.net/github/release/nado1001/sd-tailwindcss-transformer)](https://badgen.net/github/release/nado1001/sd-tailwindcss-transformer)
@@ -192,7 +191,7 @@ Optional except for `type`.
 | type              | Set the name of each theme (colors, fontSize, etc.) for `'all'` or tailwind.                                                                                                           | `'all'` or string                                                                       |
 | formatType        | Set the format of the Tailwind CSS configuration file. <br>Default value: `js`                                                                                                         | `'js'` `'cjs'`                                                                          |
 | isVariables       | Set when using CSS custom variables. <br>Default value: `false`                                                                                                                        | boolean                                                                                 |
-| extend       | Set to add transformed styles to the `'extend'` key within the `'theme'` key or not. <br>Default value: `true`                                                                                                                        | boolean                                                                                 |
+| extend            | Set to add transformed styles to the `'extend'` key within the `'theme'` key or not. <br>Default value: `true`                                                                         | boolean                                                                                 |
 | source            | [`source`](https://github.com/amzn/style-dictionary/blob/main/README.md#configjson) attribute of style-dictionary.<br>Default value: ` ['tokens/**/*.json']`                           | Array of strings                                                                        |
 | transforms        | [`platform.transforms`](https://github.com/amzn/style-dictionary/blob/main/README.md#configjson) attribute of style-dictionary.<br>Default value: `['attribute/cti','name/cti/kebab']` | Array of strings                                                                        |
 | buildPath         | [`platform.buildPath`](https://github.com/amzn/style-dictionary/blob/main/README.md#configjson) attribute of style-dictionary.<br>Default value: `'build/web/'`                        | string                                                                                  |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+//README
 # Style Dictionary Tailwind CSS Transformer
 
 [![Release](https://badgen.net/github/release/nado1001/sd-tailwindcss-transformer)](https://badgen.net/github/release/nado1001/sd-tailwindcss-transformer)
@@ -191,6 +192,7 @@ Optional except for `type`.
 | type              | Set the name of each theme (colors, fontSize, etc.) for `'all'` or tailwind.                                                                                                           | `'all'` or string                                                                       |
 | formatType        | Set the format of the Tailwind CSS configuration file. <br>Default value: `js`                                                                                                         | `'js'` `'cjs'`                                                                          |
 | isVariables       | Set when using CSS custom variables. <br>Default value: `false`                                                                                                                        | boolean                                                                                 |
+| extend       | Set to add transformed styles to the `'extend'` key within the `'theme'` key or not. <br>Default value: `true`                                                                                                                        | boolean                                                                                 |
 | source            | [`source`](https://github.com/amzn/style-dictionary/blob/main/README.md#configjson) attribute of style-dictionary.<br>Default value: ` ['tokens/**/*.json']`                           | Array of strings                                                                        |
 | transforms        | [`platform.transforms`](https://github.com/amzn/style-dictionary/blob/main/README.md#configjson) attribute of style-dictionary.<br>Default value: `['attribute/cti','name/cti/kebab']` | Array of strings                                                                        |
 | buildPath         | [`platform.buildPath`](https://github.com/amzn/style-dictionary/blob/main/README.md#configjson) attribute of style-dictionary.<br>Default value: `'build/web/'`                        | string                                                                                  |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// index.ts 
 import type { Dictionary, Config } from 'style-dictionary/types'
 import type { SdTailwindConfigType, TailwindFormatObjType } from './types'
 import {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+// index.ts 
 import type { Dictionary, Config } from 'style-dictionary/types'
 import type { SdTailwindConfigType, TailwindFormatObjType } from './types'
 import {
@@ -46,6 +47,7 @@ export const getTailwindFormat = ({
   type,
   isVariables,
   prefix,
+  extend,
   tailwind
 }: TailwindFormatObjType) => {
   const content = formatTokens(allTokens, type, isVariables, prefix)
@@ -72,6 +74,7 @@ export const getTailwindFormat = ({
       content,
       darkMode,
       tailwindContent,
+      extend,
       plugins
     )
 
@@ -85,6 +88,7 @@ export const makeSdTailwindConfig = ({
   type,
   formatType = 'js',
   isVariables = false,
+  extend = true,
   source,
   transforms,
   buildPath,
@@ -107,6 +111,7 @@ export const makeSdTailwindConfig = ({
           dictionary,
           formatType,
           isVariables,
+          extend,
           prefix,
           type,
           tailwind

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+//types.ts
 import type { Dictionary } from 'style-dictionary/types/Dictionary'
 import type { Platform } from 'style-dictionary/types/Platform'
 import type { Config } from 'style-dictionary/types/Config'
@@ -23,11 +24,12 @@ export type SdTailwindConfigType = {
   buildPath?: Platform['buildPath']
   prefix?: Platform['prefix']
   tailwind?: Partial<TailwindOptions>
+  extend?: boolean
 }
 
 export type TailwindFormatObjType = Pick<
   SdTailwindConfigType,
-  'type' | 'isVariables' | 'prefix' | 'tailwind'
+  'type' | 'isVariables' | 'prefix' | 'tailwind' | 'extend'
 > & {
   dictionary: Dictionary
   formatType: TailwindFormatType

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-//types.ts
 import type { Dictionary } from 'style-dictionary/types/Dictionary'
 import type { Platform } from 'style-dictionary/types/Platform'
 import type { Config } from 'style-dictionary/types/Config'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-//utils.ts
 import { camelCase } from 'change-case'
 import type { SdObjType, SdTailwindConfigType, TailwindOptions } from './types'
 
@@ -66,9 +65,9 @@ export const getTemplateConfigByType = (
   extend: SdTailwindConfigType['extend'],
   plugins: string[]
 ) => {
-  const extendTheme = extend ? 
-  `theme: { extend: ${unquoteFromKeys(content, type)}, },` : 
-  `theme: ${unquoteFromKeys(content, type)},`
+  const extendTheme = extend
+    ? `theme: { extend: ${unquoteFromKeys(content, type)}, },`
+    : `theme: ${unquoteFromKeys(content, type)},`
 
   const getTemplateConfig = () => {
     let config = `{

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+//utils.ts
 import { camelCase } from 'change-case'
 import type { SdObjType, SdTailwindConfigType, TailwindOptions } from './types'
 
@@ -62,16 +63,19 @@ export const getTemplateConfigByType = (
   content: string,
   darkMode: TailwindOptions['darkMode'],
   tailwindContent: TailwindOptions['content'],
+  extend: SdTailwindConfigType['extend'],
   plugins: string[]
 ) => {
+  const extendTheme = extend ? 
+  `theme: { extend: ${unquoteFromKeys(content, type)}, },` : 
+  `theme: ${unquoteFromKeys(content, type)},`
+
   const getTemplateConfig = () => {
     let config = `{
   mode: "jit",
   content: [${tailwindContent}],
   darkMode: "${darkMode}",
-  theme: {
-    extend: ${unquoteFromKeys(content, type)},
-  },`
+  ${extendTheme}`
 
     if (plugins.length > 0) {
       config += `\n plugins: [${plugins}]`


### PR DESCRIPTION
Hi @nado1001,

Apologies, but I decided to abort the previous PR and start this new one (hopefully cleaner), where I've aimed to resolve the issues you raised - all except one, which I need some clarification on please:

"However, when I run it in this state, the format of the generated tailwind.config.js is a bit broken.
I would appreciate the following change.
Please use the sd.config.js in the [example](https://github.com/nado1001/style-dictionary-tailwindcss-transformer/blob/main/example/with-css-variables/sd.config.js) and actually run it to check."

If you could please clarify, I will aim to get this resolved.

Thanks!