### PR TITLE
fix: use attributes instead of path for formatting tokens

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,11 @@ const formatTokens = (
 
     if (cur.attributes.category === type || type === 'all') {
       if (isVariables) {
-        acc[cur.path.join('.')] = prefix
+        acc[Object.values(cur.attributes).join('.')] = prefix
           ? `var(--${addHyphen(prefix) + cur.name})`
           : `var(--${cur.name})`
       } else {
-        acc[cur.path.join('.')] = cur.value
+        acc[Object.values(cur.attributes).join('.')] = cur.value
       }
     }
 


### PR DESCRIPTION
We were having an issue where the tailwind config keys were based on the folder/file structure that we were using. 

Since we cannot overwrite `token.path`, `token.attributes` are already required for the formatting and also contain each item of the path by default, I think this fix would allow you to use your custom naming convention by using a transformer like so:

```
/**
 * This transform will overwrite the attribute with a prefix of 'bar'
 * it is correctly grouped in the tailwind.config.js
 */
StyleDictionary.registerTransform({
    name: 'attribute/customNaming',
    type: 'attribute',
    transitive: true,
    matcher(token) {
        return token.path[0].startsWith('foo')
    },
    transformer({ path }) {
        const attributes = {
            category: 'bar',
            type: path[1],
            item: path[2]
        };

        return attributes
    }
});
```