### PR TITLE
fix: exclude screens values from using variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,11 @@ const formatTokens = (
     }
 
     if (cur.attributes.category === type || type === 'all') {
-      if (isVariables) {
+      /**
+       * Make sure screens values are not using CSS variables as
+       * CSS @media queries do not support CSS variables
+       */
+      if (isVariables && cur.attributes.category !== 'screens') {
         acc[Object.values(cur.attributes).join('.')] = prefix
           ? `var(--${addHyphen(prefix) + cur.name})`
           : `var(--${cur.name})`


### PR DESCRIPTION
I was running into an issue where we had a `screens` set up like so:

```
      screens: {
        xxs: "var(--viewport-breakpoint-xxs)",
        xs: "var(--viewport-breakpoint-xs)",
        sm: "var(--viewport-breakpoint-sm)",
        md: "var(--viewport-breakpoint-md)",
        lg: "var(--viewport-breakpoint-lg)",
        xl: "var(--viewport-breakpoint-xl)"
      },
```

This did not work as the Tailwind compiler just throws the CSS var in the @media query.

CSS variables are currently not supported in the spec and do not work so a raw value is needed.

I was thinking of making an `exclude` property so you can avoid making css variables for those, but I figured I'd keep the change as small as possible.

Reference:

https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties

> Note: Variables do not work inside media queries and container queries. You can use the [var()](https://developer.mozilla.org/en-US/docs/Web/CSS/var) function in any part of a value in any property on an element. You cannot use [var()](https://developer.mozilla.org/en-US/docs/Web/CSS/var) for property names, selectors, or anything aside from property values, which means you can't use it in a media query or container query.