### PR TITLE
feat(Typography): prevent camelCasing typography values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ const formatTokens = (
   const result = {}
   Object.keys(allTokenObj).forEach((key) => {
     const keys = key.split('.').filter((k) => k !== type)
-    makeSdObject(result, keys, allTokenObj[key])
+    makeSdObject(result, keys, allTokenObj[key], keys[0] !== 'typography')
   })
 
   return JSON.stringify(result, null, 2)

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -75,4 +75,40 @@ describe('makeSdObject function', () => {
       }
     })
   })
+
+  it('should camelCase values when setCasing is not given', () => {
+    const obj: { [key: string]: string } = {
+      'foo.foo-bar': 'bar',
+    }
+
+    const result = {}
+    Object.keys(obj).forEach((key) => {
+      const keys = key.split('.').filter((k) => k !== 'colors')
+      makeSdObject(result, keys, obj[key])
+    })
+
+    expect(result).toEqual({
+      foo: {
+        fooBar: 'bar'
+      }
+    })
+  })
+
+  it('should not camelCase when setCasing is set to false', () => {
+    const obj: { [key: string]: string } = {
+      'typography.foo-bar': 'bar',
+    }
+
+    const result = {}
+    Object.keys(obj).forEach((key) => {
+      const keys = key.split('.').filter((k) => k !== 'colors')
+      makeSdObject(result, keys, obj[key], false)
+    })
+
+    expect(result).toEqual({
+      typography: {
+        'foo-bar': 'bar'
+      }
+    })
+  })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ export const makeSdObject = <T extends readonly string[]>(
   obj: SdObjType<{ [key: string]: any }>,
   keys: T,
   value: string,
-  setCasing: boolean
+  setCasing = true
 ): void => {
   const lastIndex = keys.length - 1
   for (let i = 0; i < lastIndex; ++i) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,11 +8,17 @@ export const addHyphen = (str: string) => {
 export const makeSdObject = <T extends readonly string[]>(
   obj: SdObjType<{ [key: string]: any }>,
   keys: T,
-  value: string
+  value: string,
+  setCasing: boolean
 ): void => {
   const lastIndex = keys.length - 1
   for (let i = 0; i < lastIndex; ++i) {
-    const key = camelCase(keys[i])
+    let key = keys[i];
+
+    if (setCasing) {
+      key = camelCase(keys[i]);
+    }
+
     if (!(key in obj)) {
       obj[key] = {}
     }
@@ -21,6 +27,10 @@ export const makeSdObject = <T extends readonly string[]>(
 
   // https://v2.tailwindcss.com/docs/upgrading-to-v2#update-default-theme-keys-to-default
   if (keys[lastIndex] === 'DEFAULT') {
+    setCasing = false;
+  }
+
+  if (!setCasing) {
     obj[keys[lastIndex]] = value
   } else {
     obj[camelCase(keys[lastIndex])] = value


### PR DESCRIPTION
So we had an issue when combining with Tailwind CSS Typography, we would like to keep the default Tailwind format of classes which is kebab-case (`prose-foo-bar`). But since this package always transforms the keys to camelCase we were forced to use classes like `prose-fooBar`.

With this change it's configurable whether to convert it to camelCase or not. I was considering making it always kebab-case for typography classes but I was unsure if this is wanted