### PR TITLE
Remove jit mode, as it's enabled by default since V3 tailwind.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Output:
 // tailwind.config.js
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  mode: "jit",
   content: ["./src/**/*.{ts,tsx}"],
   darkMode: "class",
   theme: {
@@ -167,7 +166,6 @@ Output:
 // tailwind.config.js
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  mode: "jit",
   content: ["./src/**/*.{ts,tsx}"],
   darkMode: "class",
   theme: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,7 +86,6 @@ export const getTemplateConfigByType = (
 
   const getTemplateConfig = () => {
     let config = `{
-  mode: "jit",
   content: [${tailwindContent}],
   darkMode: "${darkMode}",
   ${extendTheme}`


### PR DESCRIPTION
as it is no longer recommended to use this flag in recent versions since V3 where it is enabled by default - see https://tailwindcss.com/blog/tailwindcss-v3#just-in-time-all-the-time